### PR TITLE
Rename header to 'Flirt of the Day' and update subtitle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import './globals.css'; // Your global styles including Tailwind
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: 'Daily Flirt',
+  title: 'Flirt of the Day',
   description: 'Daily flirty comments for every occasion',
   icons: {
     icon: '/lips.svg',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -199,16 +199,13 @@ export default function DailyFlirtPastelMinimal() {
         <div className="absolute top-4 left-4 text-5xl opacity-30 select-none">💕</div>
         <div className="absolute bottom-4 right-4 text-5xl opacity-30 select-none">✨</div>
 
-        <h1 className="text-4xl font-serif text-rose-500 mb-2 text-center">Daily Flirt</h1>
+        <h1 className="text-4xl font-serif text-rose-500 mb-2 text-center">Flirt of the Day</h1>
         <p className="text-center text-rose-400 mb-6 italic">
-          Your daily dose of tingles (
-          <button 
-            onClick={handleIYKYKClick}
-            className="text-rose-400 hover:text-rose-600 transition-colors duration-300 cursor-pointer"
-          >
-            IYKYK
-          </button>
-          )
+          Your daily{' '}
+          <button onClick={handleIYKYKClick} className="text-rose-400">
+            wink
+          </button>{' '}
+          and mischievous smile.
         </p>
 
         {/* Date Selection Section */}


### PR DESCRIPTION
## Summary
- Rename site header to “Flirt of the Day” and adjust metadata title
- Revise subtitle to “Your daily wink and mischievous smile.” with hidden wink link

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68992d85cc6c8322837e82b1a30090f1